### PR TITLE
Add test coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,8 +78,10 @@ You will see the build errors and lint warnings in the console.
 
 Runs the test watcher in an interactive mode.<br>
 By default, runs tests related to files changed since the last commit.
+You may also run `yarn coverage` to see an analysis of your test coverage.
 
-[Read more about testing.](https://github.com/facebookincubator/create-react-app/blob/master/packages/react-scripts/template/README.md#running-tests)
+
+[Read more about testing.](https://github.com/jdd1260/quickstart-react/blob/master/packages/react-scripts/template/README.md#running-tests)
 
 ### `yarn lint`
 

--- a/packages/react-scripts/scripts/init.js
+++ b/packages/react-scripts/scripts/init.js
@@ -40,6 +40,7 @@ module.exports = function(
     start: 'react-scripts start',
     build: 'react-scripts build',
     test: 'npm run lint && react-scripts test --env=jsdom',
+    coverage: 'react-scripts test --env=jsdom --coverage',
     lint: 'eslint --ext=js .',
     eject: 'react-scripts eject',
     'new-component': 'react-scripts new-component',

--- a/packages/react-scripts/scripts/utils/createJestConfig.js
+++ b/packages/react-scripts/scripts/utils/createJestConfig.js
@@ -21,7 +21,11 @@ module.exports = (resolve, rootDir, isEjecting) => {
   // TODO: I don't know if it's safe or not to just use / as path separator
   // in Jest configs. We need help from somebody with Windows to determine this.
   const config = {
-    collectCoverageFrom: ['src/**/*.{js,jsx,mjs}'],
+    collectCoverageFrom: [
+      'src/**/*.{js,jsx,mjs}',
+      '!src/**/stories.js',
+      '!src/registerServiceWorker.js',
+    ],
     setupFiles: [resolve('config/polyfills.js'), 'jest-plugin-context/setup'],
     setupTestFrameworkScriptFile: setupTestsFile,
     testMatch: [

--- a/packages/react-scripts/template/README.md
+++ b/packages/react-scripts/template/README.md
@@ -169,6 +169,7 @@ You will also see any lint errors in the console.
 
 Launches the test runner in the interactive watch mode.<br>
 See the section about [running tests](#running-tests) for more information.
+You may also run `yarn coverage` to see an analysis of your test coverage.
 
 ### `yarn build`
 
@@ -1323,7 +1324,7 @@ Similarly, `fit()` lets you focus on a specific test without running any other t
 ### Coverage Reporting
 
 Jest has an integrated coverage reporter that works well with ES6 and requires no configuration.<br>
-Run `yarn test -- --coverage` (note extra `--` in the middle) to include a coverage report like this:
+You may run `yarn coverage` to see a coverage report like this:
 
 ![coverage report](http://i.imgur.com/5bFhnTS.png)
 
@@ -1331,7 +1332,7 @@ Note that tests run much slower with coverage so it is recommended to run it sep
 
 #### Configuration
 
-The default Jest coverage configuration can be overriden by adding any of the following supported keys to a Jest config in your package.json.
+The default Jest coverage configuration can be overridden by adding any of the following supported keys to a Jest config in your package.json.
 
 Supported overrides:
  - [`collectCoverageFrom`](https://facebook.github.io/jest/docs/en/configuration.html#collectcoveragefrom-array)


### PR DESCRIPTION
This adds and configures jest test coverage:

- It adds an easy `yarn coverage` call and documents it.
- It excludes stories and src/registerServiceWorker.js from test coverage