### PR TITLE
Move store creation to separate file

### DIFF
--- a/packages/react-scripts/template/src/create-store.js
+++ b/packages/react-scripts/template/src/create-store.js
@@ -1,0 +1,15 @@
+import { createStore, applyMiddleware, compose } from 'redux';
+import promise from 'redux-promise';
+import reducers from './reducers';
+
+export default () => {
+  const composeEnhancers =
+    window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose;
+  const createStoreWithMiddleware = composeEnhancers(applyMiddleware(promise))(
+    createStore
+  );
+
+  const store = createStoreWithMiddleware(reducers);
+
+  return store;
+};

--- a/packages/react-scripts/template/src/index.js
+++ b/packages/react-scripts/template/src/index.js
@@ -1,18 +1,13 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { Provider } from 'react-redux';
-import { createStore, applyMiddleware, compose } from 'redux';
-import promise from 'redux-promise';
 
 import './index.scss';
-import reducers from './reducers';
 import registerServiceWorker from './registerServiceWorker';
-
-const composeEnhancers = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose;
-const store = createStore(reducers, composeEnhancers(applyMiddleware(promise)));
+import createStore from './create-store';
 
 ReactDOM.render(
-  <Provider store={store}>
+  <Provider store={createStore()}>
     <div>Quickstart-React</div>
   </Provider>,
   document.getElementById('root')


### PR DESCRIPTION
This pulls all logic for creating the redux store out of `index.js` and into it's own file. This allows it to grow as needed without making `index.js` messy. It also makes it easier to reuse the store in stories, tests, etc.
